### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -23,6 +23,7 @@ export var dotloop = (context: typeof glob, key: string | number, callbackFn: (n
 
         couple.forEach((name, index) => {
             let result = callbackFn(name, couple.length - 1 == index ? true : false);
+            if (holder === Object.prototype) return;
             holder[name] = result || {};
             if (typeof result === "undefined") {
                 delete holder[name];


### PR DESCRIPTION
@d3v53c (https://huntr.dev/users/d3v53c) has fixed a potential Prototype Pollution vulnerability in your repository 🔨. For more information, visit our website (https://huntr.dev/) or click the bounty URL below...

Q | A
Version Affected | *
Bug Fix | YES
Original Pull Request | https://github.com/418sec/js-dot/pull/1

If you are happy with this disclosure, we would love to get a CVE assigned to the vulnerability. Feel free to credit @d3v53c, the discloser found in the bounty URL (below) and @huntr-helper.

### User Comments:

### 📊 Metadata *

`Prototype Pollution` in `js-dot`

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-js-dot/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function returns unmodified object, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

1. Create the following PoC file:

```
// poc.js
var jsDot = require("js-dot")
var obj = {}
console.log("Before : " + {}.polluted);
jsDot.set(obj,"__proto__.polluted","Yes! Its Polluted");
console.log("After : " + {}.polluted);
```

2. Execute the following commands in terminal:

```
npm i js-dot # Install affected module
node poc.js #  Run the PoC
```

3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/107858568-e3a0a480-6e5a-11eb-9d6c-3699a5b31319.png)

After:
![image](https://user-images.githubusercontent.com/64132745/107858552-ca97f380-6e5a-11eb-8616-1c15f314cfe6.png)

### 👍 User Acceptance Testing (UAT)

After the fix, functionality is unaffected.

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1887/files
